### PR TITLE
Add fingerprint display in session list and fix mobile connection status

### DIFF
--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -12,12 +12,17 @@ async function listCommand() {
   }
 
   console.log(`${sessions.length} active session${sessions.length > 1 ? 's' : ''}:`);
+  console.log('');
 
   sessions.forEach(session => {
     const mobileIcon = session.mobileConnected ? chalk.green('🟢') : chalk.red('🔴');
     const mobileText = session.mobileConnected ? chalk.green('(Mobile connected)') : '';
 
     console.log(`  • ${chalk.cyan(session.sessionId.substring(0, 8))}  ${chalk.bold(session.projectName.padEnd(20))}  ${session.aiToolDisplayName.padEnd(15)}  ${mobileIcon} ${mobileText}`);
+
+    if (session.fingerprint) {
+      console.log(`    ${chalk.gray('Fingerprint:')} ${chalk.yellow(session.fingerprint)}`);
+    }
   });
 
   console.log('');

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -208,6 +208,9 @@ async function startCommand(directory, options) {
       // Display encryption info
       const fingerprint = generateFingerprint(publicKey);
 
+      // Save fingerprint to session
+      updateSession(session.sessionId, { fingerprint });
+
       console.log('');
       logger.success('Connected!');
       console.log(chalk.green('🔒 End-to-End Encryption: ENABLED'));
@@ -254,6 +257,16 @@ async function startCommand(directory, options) {
     // Handle resize
     wsManager.onResize((cols, rows) => {
       ptyManager.resize(cols, rows);
+    });
+
+    // Handle mobile connected
+    wsManager.onMobileConnected(() => {
+      updateSession(session.sessionId, { mobileConnected: true });
+    });
+
+    // Handle mobile disconnected
+    wsManager.onMobileDisconnected(() => {
+      updateSession(session.sessionId, { mobileConnected: false });
     });
 
     // Connect to WebSocket

--- a/lib/session/state.js
+++ b/lib/session/state.js
@@ -15,7 +15,8 @@ function createSession(projectName, workingDir, aiTool, aiToolDisplayName, aiToo
     serverUrl,
     startedAt: new Date().toISOString(),
     status: 'running',
-    mobileConnected: false
+    mobileConnected: false,
+    fingerprint: null
   };
 }
 


### PR DESCRIPTION
## Summary
- Display encryption fingerprint in `termly list` command to allow users to verify encryption keys match with mobile app
- Fix bug where mobile connection status (🟢/🔴) was not persisting to sessions registry file
- Add real-time callbacks to update `mobileConnected` status when devices connect/disconnect

## Changes
- `lib/session/state.js`: Add `fingerprint` field to session state
- `lib/commands/start.js`: Save fingerprint to registry when encryption is established, add callbacks for mobile connection status updates
- `lib/commands/list.js`: Display fingerprint below each session in yellow color

## Test plan
- [ ] Start a new session with `termly start`
- [ ] Connect mobile device and verify fingerprint is saved
- [ ] Run `termly list` and verify fingerprint is displayed
- [ ] Verify mobile connection indicator shows 🟢 (green) when connected
- [ ] Disconnect mobile device and verify indicator shows 🔴 (red)

🤖 Generated with [Claude Code](https://claude.com/claude-code)