### PR TITLE
Add intelligent terminal resize management

### DIFF
--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -263,9 +263,17 @@ async function startCommand(directory, options) {
       ptyManager.resize(cols, rows);
     });
 
+    // Handle restore resize (after mobile disconnect)
+    wsManager.onRestoreResize(() => {
+      ptyManager.restoreLocalSize();
+    });
+
     // Handle mobile connected
     wsManager.onMobileConnected(() => {
       updateSession(session.sessionId, { mobileConnected: true });
+
+      // Update PTY manager state
+      ptyManager.setMobileConnected(true);
 
       // If demo mode, send special command to trigger screen redraw
       if (selectedTool.key === 'demo') {
@@ -276,6 +284,9 @@ async function startCommand(directory, options) {
     // Handle mobile disconnected
     wsManager.onMobileDisconnected(() => {
       updateSession(session.sessionId, { mobileConnected: false });
+
+      // Update PTY manager state
+      ptyManager.setMobileConnected(false);
     });
 
     // Connect to WebSocket

--- a/lib/network/websocket.js
+++ b/lib/network/websocket.js
@@ -14,6 +14,7 @@ class WebSocketManager {
     this.mobileConnected = false;
     this.reconnectionManager = new ReconnectionManager(10);
     this.shouldReconnect = true;
+    this.restoreResizeTimer = null;
 
     // Callbacks
     this.onMobileConnectedCallback = null;
@@ -21,6 +22,7 @@ class WebSocketManager {
     this.onInputCallback = null;
     this.onResizeCallback = null;
     this.onPairedCallback = null;
+    this.onRestoreResizeCallback = null;
   }
 
   // Connect to WebSocket server
@@ -110,6 +112,9 @@ class WebSocketManager {
     console.log(chalk.green('\n📱 Mobile device connected'));
     this.mobileConnected = true;
 
+    // Cancel restore resize timer if mobile reconnected
+    this.cancelRestoreResizeTimer();
+
     if (this.onMobileConnectedCallback) {
       this.onMobileConnectedCallback();
     }
@@ -119,6 +124,9 @@ class WebSocketManager {
   handleClientDisconnected() {
     console.log(chalk.yellow('\n📱 Mobile device disconnected'));
     this.mobileConnected = false;
+
+    // Start timer to restore terminal size after delay
+    this.startRestoreResizeTimer();
 
     if (this.onMobileDisconnectedCallback) {
       this.onMobileDisconnectedCallback();
@@ -130,6 +138,9 @@ class WebSocketManager {
     console.log(chalk.green(`\n📱 Catchup requested from seq ${message.lastSeq}`));
 
     this.mobileConnected = true;
+
+    // Cancel restore resize timer if mobile reconnected
+    this.cancelRestoreResizeTimer();
 
     // Get missed messages
     const missedMessages = this.buffer.getAfter(message.lastSeq);
@@ -280,10 +291,46 @@ class WebSocketManager {
     this.onResizeCallback = callback;
   }
 
+  onRestoreResize(callback) {
+    this.onRestoreResizeCallback = callback;
+  }
+
+  // Start timer to restore terminal size after mobile disconnect
+  startRestoreResizeTimer() {
+    const { RESTORE_RESIZE_DELAY } = require('../session/pty-manager');
+
+    // Clear any existing timer
+    this.cancelRestoreResizeTimer();
+
+    logger.debug(`Starting restore resize timer (${RESTORE_RESIZE_DELAY}ms)`);
+
+    this.restoreResizeTimer = setTimeout(() => {
+      logger.debug('Restore resize timer expired, restoring terminal size');
+
+      if (this.onRestoreResizeCallback) {
+        this.onRestoreResizeCallback();
+      }
+
+      this.restoreResizeTimer = null;
+    }, RESTORE_RESIZE_DELAY);
+  }
+
+  // Cancel restore resize timer
+  cancelRestoreResizeTimer() {
+    if (this.restoreResizeTimer) {
+      logger.debug('Cancelling restore resize timer (mobile reconnected)');
+      clearTimeout(this.restoreResizeTimer);
+      this.restoreResizeTimer = null;
+    }
+  }
+
   // Close WebSocket
   close() {
     this.shouldReconnect = false;
     this.reconnectionManager.cancel();
+
+    // Cancel restore resize timer
+    this.cancelRestoreResizeTimer();
 
     if (this.ws) {
       this.ws.close(1000, 'Client closed');

--- a/lib/session/pty-manager.js
+++ b/lib/session/pty-manager.js
@@ -2,6 +2,9 @@ const pty = require('node-pty');
 const os = require('os');
 const logger = require('../utils/logger');
 
+// Delay before restoring terminal size after mobile disconnect (ms)
+const RESTORE_RESIZE_DELAY = 2000;
+
 class PTYManager {
   constructor(tool, workingDir, buffer) {
     this.tool = tool;
@@ -10,6 +13,8 @@ class PTYManager {
     this.ptyProcess = null;
     this.onDataCallback = null;
     this.onExitCallback = null;
+    this.mobileConnected = false;
+    this.localResizeListener = null;
   }
 
   // Start PTY process
@@ -69,6 +74,9 @@ class PTYManager {
         });
       }
 
+      // Setup local terminal resize listener
+      this.setupLocalResizeListener();
+
       return true;
     } catch (err) {
       logger.error(`Failed to start ${this.tool.displayName}: ${err.message}`);
@@ -125,6 +133,46 @@ class PTYManager {
     }
   }
 
+  // Restore PTY size to match local terminal
+  restoreLocalSize() {
+    const cols = process.stdout.columns || 80;
+    const rows = process.stdout.rows || 24;
+
+    logger.info(`Terminal size restored to ${cols}x${rows}`);
+    this.resize(cols, rows);
+  }
+
+  // Setup listener for local terminal resize events
+  setupLocalResizeListener() {
+    if (!process.stdout.isTTY) {
+      return;
+    }
+
+    this.localResizeListener = () => {
+      // Only resize PTY if mobile is NOT connected
+      // When mobile is connected, PTY follows mobile screen size
+      if (!this.mobileConnected) {
+        const cols = process.stdout.columns || 80;
+        const rows = process.stdout.rows || 24;
+
+        logger.debug(`Local terminal resized to ${cols}x${rows}, updating PTY`);
+        this.resize(cols, rows);
+      } else {
+        logger.debug('Local terminal resized, but mobile is connected - ignoring');
+      }
+    };
+
+    // Listen for terminal resize events (SIGWINCH)
+    process.stdout.on('resize', this.localResizeListener);
+    logger.debug('Local terminal resize listener installed');
+  }
+
+  // Set mobile connection state
+  setMobileConnected(connected) {
+    this.mobileConnected = connected;
+    logger.debug(`Mobile connection state: ${connected ? 'connected' : 'disconnected'}`);
+  }
+
   // Set data callback (for sending to WebSocket)
   onData(callback) {
     this.onDataCallback = callback;
@@ -141,6 +189,13 @@ class PTYManager {
       logger.debug('Killing PTY process');
       this.ptyProcess.kill();
       this.ptyProcess = null;
+    }
+
+    // Remove local resize listener
+    if (this.localResizeListener && process.stdout.off) {
+      process.stdout.off('resize', this.localResizeListener);
+      this.localResizeListener = null;
+      logger.debug('Local terminal resize listener removed');
     }
 
     // Restore stdin
@@ -161,3 +216,4 @@ class PTYManager {
 }
 
 module.exports = PTYManager;
+module.exports.RESTORE_RESIZE_DELAY = RESTORE_RESIZE_DELAY;


### PR DESCRIPTION
Features:
- Auto-restore terminal size to local dimensions after mobile disconnect (2s delay)
- Track local terminal resize events (SIGWINCH) and auto-update PTY when mobile not connected
- Smart resize mode switching: follow mobile when connected, follow local terminal when disconnected
- Prevent resize conflicts by ignoring local changes when mobile is active

Implementation:
- PTYManager: Added mobileConnected state tracking and local resize listener
- PTYManager: Added restoreLocalSize() method with configurable RESTORE_RESIZE_DELAY (2000ms)
- WebSocketManager: Added restore resize timer with auto-cancel on reconnect
- start.js: Connected mobile state updates to PTY manager

Behavior:
- Mobile disconnected: PTY follows local terminal size changes in real-time
- Mobile connected: PTY follows mobile screen size, ignores local changes
- Mobile reconnects within 2s: Cancel restore timer, keep mobile size
- Mobile stays disconnected 2s+: Restore to current local terminal size

🤖 Generated with [Claude Code](https://claude.com/claude-code)