### PR TITLE
Document --ai-args usage for session continuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ termly start /path/to/project --ai "claude code"
 
 # Pass arguments to AI tool
 termly start --ai aider --ai-args "--model gpt-4"
+
+# Continue previous Claude Code session (restore context after restart)
+termly start --ai claude-code --ai-args "--continue"
 ```
 
 ### Status

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -35,7 +35,7 @@ program
   .command('start [directory]', { isDefault: true })
   .description('Start AI tool with remote access')
   .option('--ai <tool>', 'Specify AI tool to use')
-  .option('--ai-args <args>', 'Additional arguments for AI tool')
+  .option('--ai-args <args>', 'Additional arguments for AI tool (e.g., "--continue" for Claude Code)')
   .option('--no-auto-detect', 'Disable AI tool auto-detection')
   .option('--debug', 'Enable debug logging')
   .action(async (directory, options) => {


### PR DESCRIPTION
## Summary
- Add example in README showing `--ai-args "--continue"` for Claude Code session restoration
- Improve CLI help text for `--ai-args` option with example

## Test plan
- [x] Verify `termly start --help` shows updated description
- [x] Verify README example is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)