### PR TITLE
v1.7.0: TUI Mode Support for OpenCode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,15 @@ The CLI uses **@lydell/node-pty** - a fork of the official node-pty that include
 - Each message has sequence number for catchup
 - Used for session resume when mobile reconnects
 - Buffer eviction: FIFO when size > maxSize
+- **TUI apps (OpenCode):** Buffer is skipped - they redraw full screen, catchup is useless
+
+**TUI Mode (`lib/session/pty-manager.js`):**
+- Enabled for apps in `tuiTools` array (currently: `['opencode']`)
+- `isTUIMode` flag set in constructor based on tool.key
+- TUI apps use alternate screen buffer, internal scroll, mouse events
+- Buffer writes skipped for TUI - no catchup on reconnect
+- Screen cleared on mobile connect/reconnect (only for TUI apps)
+- Mobile app determines TUI mode by AI tool name
 
 ### End-to-End Encryption
 
@@ -297,6 +306,13 @@ Edit `lib/ai-tools/registry.js`:
 }
 ```
 
+**Adding TUI tools (alternate screen buffer apps):**
+Edit `lib/session/pty-manager.js` and add to `tuiTools` array:
+```javascript
+this.tuiTools = ['opencode', 'your-new-tui-tool'];
+```
+TUI tools: skip buffer writes, clear screen on connect, mobile handles mouse events.
+
 ## Files to Check When...
 
 **Adding a new command:** `bin/cli.js` (register command) + `lib/commands/<name>.js` (implementation)
@@ -308,6 +324,8 @@ Edit `lib/ai-tools/registry.js`:
 **Debugging WebSocket issues:** `lib/network/websocket.js` (protocol) + `lib/network/reconnect.js` (backoff)
 
 **PTY problems:** `lib/session/pty-manager.js` (spawning/IO) + `lib/session/buffer.js` (buffering)
+
+**TUI mode issues:** `lib/session/pty-manager.js` (tuiTools array, isTUIMode flag, buffer skip)
 
 **Configuration changes:** `lib/config/manager.js` (schema must match conf requirements)
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 Access your AI coding assistants from any device. Works with Claude Code, Aider, GitHub Copilot, and any terminal-based AI tool.
 
-## What's New in v1.5
+## What's New in v1.7
 
-- 🔔 **Push Notifications Support** - CLI status tracking (idle/busy) for server-side push notifications
-- 🔗 **Improved Session Stability** - Keep session alive when WebSocket reconnection fails
+- 🖥️ **TUI Mode Support** - Full support for TUI apps like OpenCode (alternate screen buffer, mouse events)
+- 🎯 **OpenCode Integration** - Native support for OpenCode with internal scroll and mouse handling
+- 🔄 **Smarter Reconnection** - Skip useless catchup for TUI apps that redraw full screen
 
 **Previous versions:**
+- **v1.5** - Push notifications support, improved session stability
 - **v1.3** - Prebuilt binaries, improved Windows support, fast installation
 - **v1.2** - Windows output deduplication and PowerShell optimization
 - **v1.0** - Stable release with session management and E2EE
-- **v0.9** - Terminal resize support and improved reconnection
-- **v0.8** - Demo mode for Apple App Review
 
 ## Features
 
@@ -149,6 +149,7 @@ Termly CLI supports **20+ interactive terminal-based AI coding assistants**:
 
 ### Popular Open-Source Tools
 - **Aider** - AI pair programming (35k+ stars)
+- **OpenCode** - TUI-based AI coding agent with LSP integration (full TUI support!)
 - **Continue CLI** - Modular architecture
 - **OpenHands** - Open-source Devin alternative
 - **Mentat** - Git integration
@@ -158,7 +159,6 @@ Termly CLI supports **20+ interactive terminal-based AI coding assistants**:
 - **Blackbox AI** - Debugging & file editing
 
 ### Experimental/Future Support
-- **OpenCode** - When released
 - **Devin CLI** - When released
 - **Any other terminal-based AI tool**
 


### PR DESCRIPTION
## Summary

- Add TUI mode detection based on tool name (starting with `opencode`)
- Skip circular buffer writes for TUI apps to prevent catchup corruption after reconnect
- Clear local terminal screen on mobile connect for TUI apps only (prevents artifacts)
- Bump version to 1.7.0
- Update documentation (README and CLAUDE.md) with TUI mode details

## Test plan

- [ ] Start session with OpenCode: `termly start --ai opencode`
- [ ] Connect from mobile app
- [ ] Verify scroll works on first connection
- [ ] Disconnect and reconnect
- [ ] Verify scroll still works after reconnect
- [ ] Verify local terminal shows clean screen (no artifacts from mobile resize)

🤖 Generated with [Claude Code](https://claude.com/claude-code)