### PR TITLE
Add support for Oh My Pi CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Access your AI coding assistants from any device. Works with Claude Code, Aider,
 
 ## What's New in v1.9
 
-- 🎯 **Pi Coding Agent** - Support for minimal AI coding agent with extensions and 15+ LLM providers
+- 🎯 **Oh My Pi** - Support for modern AI coding agent with skills, extensions, and terminal-first workflows
 - 🚀 **Kilo Code CLI** - Full TUI support for agentic engineering CLI with 500+ models
-- 🖥️ **Enhanced TUI** - Improved TUI mode for Kilo Code with alternate screen buffer
+- 🖥️ **Enhanced TUI** - Improved TUI mode for Kilo Code and Oh My Pi with alternate screen buffer
 
 **Previous versions:**
 - **v1.8** - Added Pi Coding Agent and Kilo Code CLI support
@@ -137,7 +137,7 @@ termly list          # Quick list
 
 ## Supported AI Tools
 
-Termly CLI supports **22+ interactive terminal-based AI coding assistants**:
+Termly CLI supports **20+ interactive terminal-based AI coding assistants**:
 
 ### Official Tools from Major Companies
 - **Claude Code** (Anthropic) - AI coding assistant
@@ -152,6 +152,7 @@ Termly CLI supports **22+ interactive terminal-based AI coding assistants**:
 ### Popular Open-Source Tools
 - **Aider** - AI pair programming (35k+ stars)
 - **OpenCode** - TUI-based AI coding agent with LSP integration (full TUI support!)
+- **Oh My Pi** - Modern AI coding agent with skills, extensions, and terminal-first workflows (full TUI support!)
 - **Kilo Code CLI** - Agentic engineering CLI with 500+ models and parallel mode (full TUI support!)
 - **Pi Coding Agent** - Minimal AI agent with extensions, skills, and 15+ LLM providers
 - **Continue CLI** - Modular architecture
@@ -202,6 +203,9 @@ termly start
 
 # Use Aider explicitly
 termly start --ai aider
+
+# Use Oh My Pi explicitly
+termly start --ai omp
 
 # Use Claude Code with custom directory
 termly start /path/to/project --ai "claude code"
@@ -328,6 +332,7 @@ termly tools list  # Check what's installed
 Install an AI tool:
 - Claude Code: https://docs.claude.com
 - Aider: `pip install aider-chat`
+- Oh My Pi: `bun install -g @oh-my-pi/pi-coding-agent`
 - GitHub Copilot: `gh extension install github/gh-copilot`
 
 **Session already running?**

--- a/bin/cli-dev.js
+++ b/bin/cli-dev.js
@@ -19,7 +19,7 @@ const program = new Command();
 // Configure program
 program
   .name('termly-dev')
-  .description('Mirror your AI coding sessions to mobile - control 17+ tools from your phone (Development)')
+  .description('Mirror your AI coding sessions to mobile - control your terminal AI tools from your phone (Development)')
   .version(packageJson.version, '-v, --version', 'Show version');
 
 // Setup command
@@ -100,6 +100,7 @@ program.on('--help', () => {
   console.log('Examples:');
   console.log('  $ termly-dev                                # Auto-detect AI tool');
   console.log('  $ termly-dev --ai aider                     # Use Aider');
+  console.log('  $ termly-dev --ai omp                       # Use Oh My Pi');
   console.log('  $ termly-dev --ai "claude code"             # Use Claude Code');
   console.log('  $ termly-dev start                          # Same as just "termly-dev"');
   console.log('  $ termly-dev tools list                     # List available tools');
@@ -124,10 +125,11 @@ program.on('--help', () => {
   console.log('Supported AI Tools:');
   console.log('  • Claude Code');
   console.log('  • Aider');
+  console.log('  • OpenCode');
+  console.log('  • Oh My Pi');
+  console.log('  • Pi Coding Agent');
+  console.log('  • Kilo Code CLI');
   console.log('  • GitHub Copilot CLI');
-  console.log('  • Cursor');
-  console.log('  • Continue');
-  console.log('  • Cody');
   console.log('  • And more...');
   console.log('');
   console.log('About Termly:');

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -19,7 +19,7 @@ const program = new Command();
 // Configure program
 program
   .name('termly')
-  .description('Mirror your AI coding sessions to mobile - control 17+ tools from your phone')
+  .description('Mirror your AI coding sessions to mobile - control your terminal AI tools from your phone')
   .version(packageJson.version, '-v, --version', 'Show version');
 
 // Setup command
@@ -98,6 +98,7 @@ program.on('--help', () => {
   console.log('Examples:');
   console.log('  $ termly                                # Auto-detect AI tool');
   console.log('  $ termly --ai aider                     # Use Aider');
+  console.log('  $ termly --ai omp                       # Use Oh My Pi');
   console.log('  $ termly --ai "claude code"             # Use Claude Code');
   console.log('  $ termly start                          # Same as just "termly"');
   console.log('  $ termly tools list                     # List available tools');
@@ -122,10 +123,11 @@ program.on('--help', () => {
   console.log('Supported AI Tools:');
   console.log('  • Claude Code');
   console.log('  • Aider');
+  console.log('  • OpenCode');
+  console.log('  • Oh My Pi');
+  console.log('  • Pi Coding Agent');
+  console.log('  • Kilo Code CLI');
   console.log('  • GitHub Copilot CLI');
-  console.log('  • Cursor');
-  console.log('  • Continue');
-  console.log('  • Cody');
   console.log('  • And more...');
   console.log('');
   console.log('About Termly:');

--- a/lib/ai-tools/registry.js
+++ b/lib/ai-tools/registry.js
@@ -166,6 +166,15 @@ const AI_TOOLS = {
     website: 'https://shittycodingagent.ai',
     checkInstalled: async () => await commandExists('pi')
   },
+  'omp': {
+    key: 'omp',
+    command: 'omp',
+    args: [],
+    displayName: 'Oh My Pi',
+    description: 'Modern TUI coding agent with skills, extensions, and terminal-first workflows',
+    website: 'https://github.com/can1357/oh-my-pi',
+    checkInstalled: async () => await commandExists('omp')
+  },
   'kilo': {
     key: 'kilo',
     command: 'kilo',

--- a/lib/ai-tools/selector.js
+++ b/lib/ai-tools/selector.js
@@ -19,6 +19,7 @@ async function selectAITool(options) {
     console.error('Examples:');
     console.error('  termly start --ai aider');
     console.error('  termly start --ai "claude code"');
+    console.error('  termly start --ai omp');
     console.error('');
     process.exit(1);
   }
@@ -37,10 +38,10 @@ async function selectManualTool(toolName) {
     console.error('Available tools:');
     console.error('  • Claude Code');
     console.error('  • Aider');
-    console.error('  • GitHub Copilot CLI');
-    console.error('  • Cursor');
-    console.error('  • Continue');
-    console.error('  • Cody');
+    console.error('  • OpenCode');
+    console.error('  • Oh My Pi');
+    console.error('  • Pi Coding Agent');
+    console.error('  • Kilo Code CLI');
     console.error('  • And more...');
     console.error('');
     console.error('Use: termly tools list');
@@ -74,13 +75,10 @@ async function autoSelectTool() {
     console.error(chalk.red('❌ No AI tools detected'));
     console.error('');
     console.error('Please install an AI coding assistant:');
-    console.error('  • Claude Code');
-    console.error('  • Aider');
-    console.error('  • GitHub Copilot CLI');
-    console.error('  • Cursor');
-    console.error('  • Continue');
-    console.error('  • Cody');
-    console.error('  • And more...');
+    console.error('  • Claude Code: https://docs.claude.com');
+    console.error('  • Aider: pip install aider-chat');
+    console.error('  • Oh My Pi: bun install -g @oh-my-pi/pi-coding-agent');
+    console.error('  • GitHub Copilot: gh extension install github/gh-copilot');
     console.error('');
     console.error('See all tools: termly tools list');
     console.error('Then try again: termly start');
@@ -126,7 +124,8 @@ function getInstallInstructions(tool) {
     'github-copilot': 'gh extension install github/gh-copilot',
     'cursor': 'https://cursor.com/blog/cli',
     'continue': 'npm install -g continue-dev',
-    'cody': 'npm install -g @sourcegraph/cody'
+    'cody': 'npm install -g @sourcegraph/cody',
+    'omp': 'bun install -g @oh-my-pi/pi-coding-agent'
   };
 
   return instructions[tool.key] || tool.website;

--- a/lib/commands/tools.js
+++ b/lib/commands/tools.js
@@ -43,6 +43,7 @@ async function toolsDetectCommand() {
     console.log('Install an AI coding assistant:');
     console.log('  • Claude Code: https://docs.claude.com');
     console.log('  • Aider: pip install aider-chat');
+    console.log('  • Oh My Pi: bun install -g @oh-my-pi/pi-coding-agent');
     console.log('  • GitHub Copilot: gh extension install github/gh-copilot');
     return;
   }

--- a/lib/session/pty-manager.js
+++ b/lib/session/pty-manager.js
@@ -17,7 +17,7 @@ class PTYManager {
     this.outputPaused = false; // Flag to pause PTY output during reconnection
 
     // TUI tools that use alternate screen buffer (internal scroll, mouse events)
-    this.tuiTools = ['opencode', 'kilo'];
+    this.tuiTools = ['opencode', 'omp', 'kilo'];
     this.isTUIMode = this.tuiTools.includes(tool.key);
 
     // Deduplication state (for Windows cmd.exe duplicate output bug)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@termly-dev/cli",
-  "version": "1.2.1",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@termly-dev/cli",
-      "version": "1.2.1",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",

--- a/package.dev.json
+++ b/package.dev.json
@@ -1,7 +1,7 @@
 {
   "name": "@termly-dev/cli-dev",
   "version": "1.9.0",
-  "description": "Mirror your AI coding sessions to mobile - control Claude, Aider, Copilot, and 19+ tools from your phone (Development version)",
+  "description": "Mirror your AI coding sessions to mobile - control your terminal AI tools from your phone (Development version)",
   "main": "index.js",
   "bin": {
     "termly-dev": "./bin/cli-dev.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@termly-dev/cli",
   "version": "1.9.0",
-  "description": "Mirror your AI coding sessions to mobile - control Claude, Aider, Copilot, and 19+ tools from your phone",
+  "description": "Mirror your AI coding sessions to mobile - control your terminal AI tools from your phone",
   "main": "index.js",
   "bin": {
     "termly": "./bin/cli.js"


### PR DESCRIPTION
## Summary
- add Oh My Pi as a separate supported tool using the modern `omp` executable
- keep legacy `pi` support unchanged and mark `omp` as a TUI tool
- refresh CLI/help/install surfaces and docs to mention Oh My Pi and remove stale tool-count copy

## Testing
- node bin/cli.js tools info omp
- node bin/cli.js tools list
- node bin/cli.js --help
- node bin/cli.js tools detect
- node bin/cli.js "<tmpdir>" --ai omp --debug (verified pairing UI shows Oh My Pi metadata)

Closes #31
Issue: https://github.com/termly-dev/termly-cli/issues/31
