### PR TITLE
fix: handle pairing_expired + bump version to 1.9.3

### DIFF
--- a/lib/network/websocket.js
+++ b/lib/network/websocket.js
@@ -361,7 +361,7 @@ class WebSocketManager {
     }
 
     // Check if session expired or not found
-    if (errorData && (errorData.error === 'session_expired' || errorData.error === 'session_not_found')) {
+    if (errorData && (errorData.error === 'session_expired' || errorData.error === 'session_not_found' || errorData.error === 'pairing_expired')) {
       console.log(chalk.yellow(`\n⚠️  ${errorData.message || 'Session no longer valid'}`));
       console.log(chalk.yellow('Please restart the CLI session:'));
       console.log(chalk.cyan('  termly start'));

--- a/package.dev.json
+++ b/package.dev.json
@@ -1,6 +1,6 @@
 {
   "name": "@termly-dev/cli-dev",
-  "version": "1.9.0",
+  "version": "1.9.3",
   "description": "Mirror your AI coding sessions to mobile - control Claude, Aider, Copilot, and 19+ tools from your phone (Development version)",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@termly-dev/cli",
-  "version": "1.9.0",
+  "version": "1.9.3",
   "description": "Mirror your AI coding sessions to mobile - control Claude, Aider, Copilot, and 19+ tools from your phone",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Handle `pairing_expired` error from server — exit cleanly instead of reconnect loop
- Bump version to 1.9.3

## Changes
- `lib/network/websocket.js`: add `pairing_expired` to terminal error codes that call `process.exit(1)`
- `package.json` / `package.dev.json`: version `1.9.0` → `1.9.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)