### PR TITLE
v1.9.5: Qwen Code support + security fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ termly list          # Quick list
 
 ## Supported AI Tools
 
-Termly CLI supports **22+ interactive terminal-based AI coding assistants**:
+Termly CLI supports **23+ interactive terminal-based AI coding assistants**:
 
 ### Official Tools from Major Companies
 - **Claude Code** (Anthropic) - AI coding assistant
@@ -148,6 +148,7 @@ Termly CLI supports **22+ interactive terminal-based AI coding assistants**:
 - **Google Gemini CLI** (Google) - 1M token context window
 - **Grok CLI** (xAI) - X.AI's coding assistant
 - **OpenAI Codex CLI** (OpenAI) - Code generation model
+- **Qwen Code** (Alibaba) - Agentic coding CLI optimized for Qwen3-Coder models
 
 ### Popular Open-Source Tools
 - **Aider** - AI pair programming (35k+ stars)

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 Access your AI coding assistants from any device. Works with Claude Code, Aider, GitHub Copilot, and any terminal-based AI tool.
 
-## What's New in v1.9
+## What's New in v1.9.5
 
-- 🎯 **Pi Coding Agent** - Support for minimal AI coding agent with extensions and 15+ LLM providers
-- 🚀 **Kilo Code CLI** - Full TUI support for agentic engineering CLI with 500+ models
-- 🖥️ **Enhanced TUI** - Improved TUI mode for Kilo Code with alternate screen buffer
+- 🐼 **Qwen Code** - Added support for Alibaba's agentic coding CLI optimized for Qwen3-Coder models
+- 🔒 **Security** - Patched 8 Dependabot alerts (axios, lodash, ajv, follow-redirects)
 
 **Previous versions:**
+- **v1.9.3** - Handle `pairing_expired` error from server on reconnect
+- **v1.9** - Pi Coding Agent, Kilo Code CLI, enhanced TUI mode
 - **v1.8** - Added Pi Coding Agent and Kilo Code CLI support
 - **v1.7** - TUI mode support, OpenCode integration, smarter reconnection
 - **v1.5** - Push notifications support, improved session stability

--- a/lib/ai-tools/registry.js
+++ b/lib/ai-tools/registry.js
@@ -175,6 +175,15 @@ const AI_TOOLS = {
     website: 'https://kilo.ai',
     checkInstalled: async () => await commandExists('kilo')
   },
+  'qwen': {
+    key: 'qwen',
+    command: 'qwen',
+    args: [],
+    displayName: 'Qwen Code',
+    description: 'Alibaba\'s agentic coding CLI optimized for Qwen3-Coder models',
+    website: 'https://github.com/QwenLM/qwen-code',
+    checkInstalled: async () => await commandExists('qwen')
+  },
   'demo': {
     key: 'demo',
     command: 'node',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@termly-dev/cli",
-  "version": "1.2.1",
+  "version": "1.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@termly-dev/cli",
-      "version": "1.2.1",
+      "version": "1.9.5",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.6.0",
+        "axios": "^1.15.0",
         "chalk": "^4.1.2",
         "commander": "^11.0.0",
         "conf": "^10.2.0",
@@ -131,9 +131,9 @@
       ]
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -230,14 +230,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/base64-js": {
@@ -619,9 +619,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -639,9 +639,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -893,9 +893,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -1079,10 +1079,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/qrcode-terminal": {
       "version": "0.12.0",

--- a/package.dev.json
+++ b/package.dev.json
@@ -1,6 +1,6 @@
 {
   "name": "@termly-dev/cli-dev",
-  "version": "1.9.3",
+  "version": "1.9.5",
   "description": "Mirror your AI coding sessions to mobile - control Claude, Aider, Copilot, and 19+ tools from your phone (Development version)",
   "main": "index.js",
   "bin": {
@@ -45,7 +45,7 @@
     "scripts/"
   ],
   "dependencies": {
-    "axios": "^1.6.0",
+    "axios": "^1.15.0",
     "chalk": "^4.1.2",
     "commander": "^11.0.0",
     "conf": "^10.2.0",
@@ -55,5 +55,9 @@
     "semver": "^7.7.3",
     "uuid": "^9.0.0",
     "ws": "^8.14.0"
+  },
+  "overrides": {
+    "lodash": "^4.18.1",
+    "ajv": "^8.18.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@termly-dev/cli",
-  "version": "1.9.3",
+  "version": "1.9.5",
   "description": "Mirror your AI coding sessions to mobile - control Claude, Aider, Copilot, and 19+ tools from your phone",
   "main": "index.js",
   "bin": {
@@ -44,7 +44,7 @@
     "scripts/"
   ],
   "dependencies": {
-    "axios": "^1.6.0",
+    "axios": "^1.15.0",
     "chalk": "^4.1.2",
     "commander": "^11.0.0",
     "conf": "^10.2.0",
@@ -54,5 +54,9 @@
     "semver": "^7.7.3",
     "uuid": "^9.0.0",
     "ws": "^8.14.0"
+  },
+  "overrides": {
+    "lodash": "^4.18.1",
+    "ajv": "^8.18.0"
   }
 }


### PR DESCRIPTION
## Summary
- Add Qwen Code (Alibaba) to the AI tools registry
- Patch all 8 Dependabot alerts (axios, lodash, ajv, follow-redirects)
- Bump version to 1.9.5

## Security fixes
- **axios** `^1.6.0` → `^1.15.0` — fixes 2 critical SSRF + 1 high DoS
- **lodash** override `^4.18.1` — fixes 1 high code injection + 2 medium prototype pollution
- **ajv** override `^8.18.0` — fixes ReDoS
- **follow-redirects** `1.16.0` via `npm audit fix` — fixes auth header leak to cross-domain redirects

`npm audit` reports **0 vulnerabilities** after changes.

## Test plan
- [x] `npm install` clean, no warnings
- [x] `npm audit` = 0 vulnerabilities
- [x] `termly config` smoke test
- [ ] End-to-end: pair with mobile, send command, receive response
- [ ] Publish `@termly-dev/cli-dev@1.9.5` and verify in dev env before prod publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)