### PR TITLE
fix(ai-tools): honor defaultAI config in `termly start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ termly config set defaultAI aider
 termly config get defaultAI
 ```
 
+`defaultAI` is used by `termly start` when no `--ai` flag is given. If the
+configured tool is unknown or not installed, Termly warns and falls back to
+auto-detection instead of failing.
+
 **Note:** Server URL is determined by environment and cannot be changed via config.
 
 ### Cleanup

--- a/lib/ai-tools/selector.js
+++ b/lib/ai-tools/selector.js
@@ -2,6 +2,7 @@ const inquirer = require('inquirer');
 const chalk = require('chalk');
 const { detectInstalledTools, isToolInstalled } = require('./detector');
 const { getToolByKey } = require('./registry');
+const { getDefaultAI } = require('../config/manager');
 const logger = require('../utils/logger');
 
 // Select AI tool based on options
@@ -10,6 +11,12 @@ async function selectAITool(options) {
   if (options.ai) {
     logger.debug(`Manual tool selection: ${options.ai}`);
     return await selectManualTool(options.ai);
+  }
+
+  // Configured default (termly setup / termly config set defaultAI <tool>)
+  const configuredTool = await selectConfiguredDefault();
+  if (configuredTool) {
+    return configuredTool;
   }
 
   // No auto-detect mode
@@ -25,6 +32,40 @@ async function selectAITool(options) {
 
   // Auto-detect mode
   return await autoSelectTool();
+}
+
+// Configured default tool selection
+//
+// Unlike --ai, `defaultAI` is a stored preference that may have been set long
+// ago, so a stale value must never kill `termly start`: warn and let the caller
+// fall back to auto-detection.
+async function selectConfiguredDefault() {
+  const defaultAI = getDefaultAI();
+
+  if (!defaultAI) {
+    return null;
+  }
+
+  logger.debug(`Configured defaultAI: ${defaultAI}`);
+
+  const tool = getToolByKey(defaultAI);
+
+  if (!tool) {
+    logger.warn(`Configured default AI "${defaultAI}" is unknown - falling back to auto-detection`);
+    console.log(chalk.dim('   Change it with: termly config set defaultAI <tool>'));
+    return null;
+  }
+
+  const result = await isToolInstalled(tool.key);
+
+  if (!result.installed) {
+    logger.warn(`Configured default AI ${tool.displayName} is not installed - falling back to auto-detection`);
+    console.log(chalk.dim('   Change it with: termly config set defaultAI <tool>'));
+    return null;
+  }
+
+  console.log(chalk.green(`Using ${result.tool.displayName} v${result.tool.version} (configured default)`));
+  return result.tool;
 }
 
 // Manual tool selection


### PR DESCRIPTION
## Problem

`defaultAI` is currently a **write-only config key**.

Three code paths write it, none read it:

| Location | Role |
|---|---|
| `lib/config/manager.js:7` | defines the schema |
| `lib/commands/setup.js:30` | `termly setup` stores the answer |
| `lib/commands/config.js` | `termly config set defaultAI <tool>` stores it, `termly config` prints it |
| `lib/config/manager.js:44` | `getDefaultAI()` — exported, **zero call sites** |

`grep -rn "getDefaultAI" lib/` on `main` returns only the definition and the export.

The user-visible effect: someone runs `termly setup`, answers "Default AI tool: claude-code", sees `Default AI: claude-code` in `termly config` — and still gets the interactive `Multiple AI tools detected: Which tool would you like to use?` prompt on every single `termly start`. The setting silently does nothing.

## Fix

`selectAITool()` now consults the config between the `--ai` flag and auto-detection:

```
--ai flag  ->  defaultAI config  ->  --no-auto-detect error  ->  auto-detect
```

`--ai` still wins, so nothing changes for explicit invocations.

## Stale values are non-fatal

Unlike `--ai`, `defaultAI` is a stored preference that may have been set months ago. Routing it straight through `selectManualTool()` would have made `termly start` **exit 1** the day a user uninstalls or renames their configured tool.

So `selectConfiguredDefault()` warns and returns `null`, letting the caller fall back to auto-detection:

```
⚠️  Configured default AI Aider is not installed - falling back to auto-detection
   Change it with: termly config set defaultAI <tool>
✓ Using Claude Code v2.1.263 (auto-detected)
```

## Behavior change

Users who already have `defaultAI` set — possibly without realizing, since it never did anything — will stop seeing the tool-selection prompt. That is the behavior the setting always advertised, but it is a change worth calling out in release notes.

## Verification

All four paths exercised against a stubbed `getDefaultAI()`:

| Scenario | Result |
|---|---|
| `--ai claude-code` + `defaultAI=demo` | `claude-code` — flag wins |
| `defaultAI=demo` (installed) | `Using Demo Mode (configured default)` |
| `defaultAI=nonexistent-xyz` | warns, falls back to auto-detect |
| `defaultAI=aider` (not installed) | warns, falls back to auto-detect |
| `defaultAI=''` | auto-detect, unchanged |

Scope: `lib/ai-tools/selector.js` (+41) and a README note (+4). No dependency, protocol, or config-schema changes.
